### PR TITLE
update auto-generated URLs to open problems in "daily question" view

### DIFF
--- a/.github/workflows/create_new_note.yml
+++ b/.github/workflows/create_new_note.yml
@@ -25,14 +25,14 @@ jobs:
 
           TITLE=$(jq -r '.data.activeDailyCodingChallengeQuestion.question.title' response.json)
           TITLE_SLUG=$(jq -r '.data.activeDailyCodingChallengeQuestion.question.titleSlug' response.json)
-          LINK="https://leetcode.com/problems/${TITLE_SLUG}"
+          LINK="https://leetcode.com/problems/${TITLE_SLUG}/description/?envType=daily-question"
           GITHUB_USERNAME="${{ github.actor }}"
 
           # Create problem directory and note
           PROBLEM_DIR="problems/${PROBLEM_ID}"
           NOTE_FILE="${PROBLEM_DIR}/${GITHUB_USERNAME}.md"
           mkdir -p "${PROBLEM_DIR}"
-          
+
           # Customize template and write to new file
           sed "s|<NUMBER>|${PROBLEM_ID}|g; s|<TITLE>|${TITLE}|g; s|<LINK TO DESCRIPTION>|${LINK}|g" problems/template.md > "${NOTE_FILE}"
 

--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ Each day (ideally) we'll attempt the daily [leetcode](https://leetcode.com) prob
 
 | 📆 Date         | ⚙️ Problem                                                                                                     | 📝 Link to notes                                                                                             | 🚦 Difficulty |
 |--------------|-------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------|------------|
-| July 1, 2024 | [1550](https://leetcode.com/problems/three-consecutive-odds/description/)                                         | [Click here](https://github.com/ContextLab/leetcode-solutions/tree/main/problems/1550)                     | 🟢  Easy        |
-| July 2, 2024 | [350](https://leetcode.com/problems/intersection-of-two-arrays-ii/)                                         | [Click here](https://github.com/ContextLab/leetcode-solutions/tree/main/problems/350)                     | 🟢  Easy        |
-| July 3, 2024 | [1509](https://leetcode.com/problems/minimum-difference-between-largest-and-smallest-value-in-three-moves/) | [Click here](https://github.com/ContextLab/leetcode-solutions/tree/main/problems/1509)                    | 🟡  Medium      |
-| July 4, 2024 | [2181](https://leetcode.com/problems/merge-nodes-in-between-zeros/)                                         | [Click here](https://github.com/ContextLab/leetcode-solutions/tree/main/problems/2181)                    | 🟡  Medium      |
-| July 5, 2024 | [2058](https://leetcode.com/problems/find-the-minimum-and-maximum-number-of-nodes-between-critical-points/) | [Click here](https://github.com/ContextLab/leetcode-solutions/tree/main/problems/2058)                    | 🟡  Medium      |
-| July 6, 2024 | [2582](https://leetcode.com/problems/pass-the-pillow) | [Click here](https://github.com/ContextLab/leetcode-solutions/tree/main/problems/2582) | 🟢 Easy |
-| July 7, 2024 | [1518](https://leetcode.com/problems/water-bottles) | [Click here](https://github.com/ContextLab/leetcode-solutions/tree/main/problems/1518) | 🟢 Easy |
+| July 1, 2024 | [1550](https://leetcode.com/problems/three-consecutive-odds/description/description/?envType=daily-question)                                         | [Click here](https://github.com/ContextLab/leetcode-solutions/tree/main/problems/1550)                     | 🟢  Easy        |
+| July 2, 2024 | [350](https://leetcode.com/problems/intersection-of-two-arrays-ii/description/?envType=daily-question)                                         | [Click here](https://github.com/ContextLab/leetcode-solutions/tree/main/problems/350)                     | 🟢  Easy        |
+| July 3, 2024 | [1509](https://leetcode.com/problems/minimum-difference-between-largest-and-smallest-value-in-three-moves/description/?envType=daily-question) | [Click here](https://github.com/ContextLab/leetcode-solutions/tree/main/problems/1509)                    | 🟡  Medium      |
+| July 4, 2024 | [2181](https://leetcode.com/problems/merge-nodes-in-between-zeros/description/?envType=daily-question)                                         | [Click here](https://github.com/ContextLab/leetcode-solutions/tree/main/problems/2181)                    | 🟡  Medium      |
+| July 5, 2024 | [2058](https://leetcode.com/problems/find-the-minimum-and-maximum-number-of-nodes-between-critical-points/description/?envType=daily-question) | [Click here](https://github.com/ContextLab/leetcode-solutions/tree/main/problems/2058)                    | 🟡  Medium      |
+| July 6, 2024 | [2582](https://leetcode.com/problems/pass-the-pillow/description/?envType=daily-question) | [Click here](https://github.com/ContextLab/leetcode-solutions/tree/main/problems/2582) | 🟢 Easy |
+| July 7, 2024 | [1518](https://leetcode.com/problems/water-bottles/description/?envType=daily-question) | [Click here](https://github.com/ContextLab/leetcode-solutions/tree/main/problems/1518) | 🟢 Easy |
 
 # Join our discussion!
 

--- a/update_readme.py
+++ b/update_readme.py
@@ -36,7 +36,7 @@ if 'data' in data and 'activeDailyCodingChallengeQuestion' in data['data']:
     problem_id = problem['questionFrontendId']
     title = problem['title']
     title_slug = problem['titleSlug']
-    link = f"https://leetcode.com/problems/{title_slug}"
+    link = f"https://leetcode.com/problems/{title_slug}/description/?envType=daily-question"
     difficulty = problem['difficulty']
     difficulty_icon = "🟢" if difficulty == "Easy" else "🟡" if difficulty == "Medium" else "🔴"
     note_link = f"{repo_url}/tree/main/problems/{problem_id}"


### PR DESCRIPTION
This is a minor QoL tweak, feel free to close without merging if you'd prefer not to have this.

I added `/description/?envType=daily-question` to the ends of the leetcode URLs that the two GitHub workflows automatically generate for the README and problem templates. I also added it to the existing leetcode URLs in the README. 

The only difference this makes in the target webpage is that the menu button in the top left corner is labeled "Daily Question" instead of "Problem List", and clicking it shows the previous 150 days' daily questions in chronological order instead of the 150 questions with numeric IDs closest to the current question's ID. I've found this handy for looking back at & navigating between previous problems and seeing which ones I still need to do. It also matches the order of the problems listed in the README.